### PR TITLE
Bump grpcio package versions for to upgrade protobuf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ aiologger = "^0.7.0"
 aiocsv = "^1.3.2"
 orjson = "^3.10.15"
 numpy = "^2.2.2"
-grpcio = "^1.70.0"
-grpcio-tools = "^1.70.0"
+grpcio = "^1.75.1"
+grpcio-tools = "^1.75.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest-cov = "^6.0.0"


### PR DESCRIPTION
grpcio-tools depends on protobuf-5.26.1, bump to latest to transitively upgrade to version that doesn't have security vulnerabilities